### PR TITLE
Fixed formatting of content.json

### DIFF
--- a/library/Generator.js
+++ b/library/Generator.js
@@ -33,7 +33,7 @@ class Generator {
 
   writeContentsJson(json, folderPath) {
     const path = folderPath.concat('/Contents.json')
-    Fs.writeFileSync(path, JSON.stringify(json, null, 2).replace(new RegExp(":", "g"), " :"))
+    Fs.writeFileSync(path, JSON.stringify(json, null, 2).replace(new RegExp(": ", "g"), " :"))
   }
 
   writeImages(originalImagePath, contentsJson, folderPath) {

--- a/library/Generator.js
+++ b/library/Generator.js
@@ -33,7 +33,7 @@ class Generator {
 
   writeContentsJson(json, folderPath) {
     const path = folderPath.concat('/Contents.json')
-    Fs.writeFileSync(path, JSON.stringify(json, null, 2).replace(new RegExp(": ", "g"), " :"))
+    Fs.writeFileSync(path, JSON.stringify(json, null, 2).replace(new RegExp(": ", "g"), " : "))
   }
 
   writeImages(originalImagePath, contentsJson, folderPath) {

--- a/library/Generator.js
+++ b/library/Generator.js
@@ -33,7 +33,7 @@ class Generator {
 
   writeContentsJson(json, folderPath) {
     const path = folderPath.concat('/Contents.json')
-    Fs.writeFileSync(path, JSON.stringify(json))
+    Fs.writeFileSync(path, JSON.stringify(json, null, 2).replace(new RegExp(":", "g"), " :"))
   }
 
   writeImages(originalImagePath, contentsJson, folderPath) {


### PR DESCRIPTION
Overview
Fixed a problem that the content.json was not well shaped and a large amount of difference was generated when replacing it with a genuine AppIcon

Details
Although content.json for INDEX exists inside AppIcon, shaping is insufficient as compared with the original one, so a lot of git difference will be generated
I think it is a minor fix that many people would not need readability, but for me it is important for future maintenance so I will send you this fix