### PR TITLE
Add option to generate Icns file

### DIFF
--- a/src/components/InputComponent.js
+++ b/src/components/InputComponent.js
@@ -150,7 +150,7 @@ class InputComponent extends React.Component {
     }
 
     const choices = [
-      "iOS (iPhone)", "iOS (iPad)", "iOS (Universal)", "macOS", "tvOS", "watchOS"
+      "iOS (iPhone)", "iOS (iPad)", "iOS (Universal)", "macOS", "tvOS", "watchOS", "Icns"
     ]
 
     const choiceElements = choices.map((name) => {


### PR DESCRIPTION
This adds an option to automatically generate an Icns file from the generated mac icon set. This should save folks some time so they don't have to do the additional manual steps to make Icns files... which is something I do often, as I love to make custom icons for all of the apps on my mac.

Also, I wrapped the Sharp calls in a promise so that the additional processing needed for making Icns would wait until after all of the image processing finished!